### PR TITLE
example of container-fs read-only

### DIFF
--- a/21.0/apache/Dockerfile
+++ b/21.0/apache/Dockerfile
@@ -1,7 +1,6 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
 FROM php:7.4-apache-buster
 
-ENV NEXTCLOUD_VERSION 21.0.3
 ENV PHP_MEMORY_LIMIT 512M
 ENV PHP_UPLOAD_LIMIT 512M
 
@@ -123,7 +122,8 @@ RUN a2enmod headers rewrite remoteip ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
     a2enconf remoteip
 
-
+ARG NEXTCLOUD_VERSION=21.0.3
+ENV NEXTCLOUD_VERSION=${NEXTCLOUD_VERSION}
 RUN set -ex; \
     fetchDeps=" \
         gnupg \

--- a/21.0/apache/Dockerfile
+++ b/21.0/apache/Dockerfile
@@ -1,6 +1,10 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
 FROM php:7.4-apache-buster
 
+ENV NEXTCLOUD_VERSION 21.0.3
+ENV PHP_MEMORY_LIMIT 512M
+ENV PHP_UPLOAD_LIMIT 512M
+
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
     \
@@ -17,8 +21,6 @@ RUN set -ex; \
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
-ENV PHP_MEMORY_LIMIT 512M
-ENV PHP_UPLOAD_LIMIT 512M
 RUN set -ex; \
     \
     savedAptMark="$(apt-mark showmanual)"; \
@@ -121,7 +123,6 @@ RUN a2enmod headers rewrite remoteip ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
     a2enconf remoteip
 
-ENV NEXTCLOUD_VERSION 21.0.3
 
 RUN set -ex; \
     fetchDeps=" \
@@ -139,19 +140,44 @@ RUN set -ex; \
 # gpg key from https://nextcloud.com/nextcloud.asc
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
     gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
-    gpgconf --kill all; \
+    tar -xjf nextcloud.tar.bz2 --strip-components=1 -C . \
+&& gpgconf --kill all; \
     rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
-    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
-    mkdir -p /usr/src/nextcloud/data; \
-    mkdir -p /usr/src/nextcloud/custom_apps; \
-    chmod +x /usr/src/nextcloud/occ; \
+    rm -rf "$GNUPGHOME" /var/www/html/updater; \
+    chmod +x /var/www/html/occ; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /usr/src/nextcloud \
+ && mv /var/www/html/themes /usr/src/nextcloud/ \
+ && mv /var/www/html/config /usr/src/nextcloud/
 
-COPY *.sh upgrade.exclude /
+### Volumes
+# to store the pid
+VOLUME /run/apache2
+# /tmp for session data
+VOLUME /tmp
+#######
+# A volume for each directory within the nextcloud installation, so that
+# 1/ each one can be swapped out with a persistent volume 
+# 2/ file access is faster as it is not part of the overlay file-system
+# 3/ if 2/ is crafted carefully it will eventually allow the container FS to be mounted read-only, which helps security
+VOLUME /var/www/html/3rdparty
+VOLUME /var/www/html/apps
+VOLUME /var/www/html/config
+VOLUME /var/www/html/core
+VOLUME /var/www/html/custom_apps
+VOLUME /var/www/html/data
+VOLUME /var/www/html/lib
+VOLUME /var/www/html/ocm-provider
+VOLUME /var/www/html/ocs
+VOLUME /var/www/html/ocs-provider
+VOLUME /var/www/html/resources
+VOLUME /var/www/html/themes
+
+COPY entrypoint.sh /usr/local/bin/
+COPY cron.sh /
 COPY config/* /usr/src/nextcloud/config/
 
-ENTRYPOINT ["/entrypoint.sh"]
-CMD ["apache2-foreground"]
+ENTRYPOINT []
+CMD ["/usr/local/bin/entrypoint.sh", "apache2-foreground"]

--- a/21.0/apache/docker-compose.yml
+++ b/21.0/apache/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+    
+services:
+  db:
+    image: mariadb:10.5
+    command: --transaction-isolation=READ-COMMITTED
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: unless-stopped
+    environment:
+      MARIADB_RANDOM_ROOT_PASSWORD: "yes"
+      MYSQL_DATABASE: nextcloud
+      MYSQL_USER: nextcloud
+      MYSQL_PASSWORD: nextcloud
+    
+  nextcloud:
+    depends_on:
+      - db
+    image: ${NC_IMAGE_NAME:-nextcloud:latest}
+    volumes:
+      - nextcloud_data:/var/www/html/data
+      - nextcloud_apps:/var/www/html/apps
+      - nextcloud_config:/var/www/html/config
+      - nextcloud_themes:/var/www/html/themes
+    ports:
+      - "8000:80"
+    restart: always
+    environment:
+      NEXTCLOUD_ADMIN_USER: adminstrator
+      NEXTCLOUD_ADMIN_PASSWORD: adminpass
+      NEXTCLOUD_TRUSTED_DOMAINS: localhost
+      MYSQL_DATABASE: nextcloud
+      MYSQL_PASSWORD: nextcloud
+      MYSQL_USER: nextcloud
+      MYSQL_HOST: db
+volumes:
+  db_data: {}
+  nextcloud_data: {}
+  nextcloud_apps: {}
+  nextcloud_config: {}
+  nextcloud_themes: {}

--- a/21.0/apache/docker-compose.yml
+++ b/21.0/apache/docker-compose.yml
@@ -6,7 +6,10 @@ services:
     command: --transaction-isolation=READ-COMMITTED
     volumes:
       - db_data:/var/lib/mysql
+      - /run/mysqld/
+      - /tmp
     restart: unless-stopped
+    read_only: true
     environment:
       MARIADB_RANDOM_ROOT_PASSWORD: "yes"
       MYSQL_DATABASE: nextcloud
@@ -17,6 +20,7 @@ services:
     depends_on:
       - db
     image: ${NC_IMAGE_NAME:-nextcloud:latest}
+    read_only: true
     volumes:
       - nextcloud_data:/var/www/html/data
       - nextcloud_apps:/var/www/html/apps
@@ -26,9 +30,10 @@ services:
       - "8000:80"
     restart: always
     environment:
-      NEXTCLOUD_ADMIN_USER: adminstrator
+      NEXTCLOUD_ADMIN_USER: administrator
       NEXTCLOUD_ADMIN_PASSWORD: adminpass
       NEXTCLOUD_TRUSTED_DOMAINS: localhost
+      ### Commented out as this will make the entrypoint assume that a clean install is appropriate
       MYSQL_DATABASE: nextcloud
       MYSQL_PASSWORD: nextcloud
       MYSQL_USER: nextcloud


### PR DESCRIPTION
Some tweaks to the entrypoint and Dockerfile to not copy files that are tied to a version of nextcloud.
Instead use multiple volumes to hold r/w directories.

```
docker build -t nextcloud/apache:21.0.2 --build-arg=NEXTCLOUD_VERSION=21.0.2 .
docker build -t nextcloud/apache:21.0.3 --build-arg=NEXTCLOUD_VERSION=21.0.3 .
export NC_IMAGE_NAME=nextcloud/apache:21.0.2
```
### Start the Stack
First we start the database in the background

```
$ docker-compose up -d db
Creating volume "apache_nextcloud_data" with default driver
Creating volume "apache_nextcloud_apps" with default driver
Creating volume "apache_nextcloud_config" with default driver
Creating volume "apache_nextcloud_themes" with default driver
Creating apache_db_1 ... done
```

Afterwards starting the nextcloud:21.0.2 instance
```
$ docker-compose up nextcloud 
apache_db_1 is up-to-date
Creating apache_nextcloud_1 ...
Attaching to apache_nextcloud_1
nextcloud_1  | + expr apache2-foreground : apache
nextcloud_1  | + [ -n  ]
nextcloud_1  | + expr apache2-foreground : apache
nextcloud_1  | + [ -n  ]
nextcloud_1  | + installed_version=0.0.0.0
nextcloud_1  | + php -r require "/var/www/html/version.php"; echo implode(".", $OC_Version);
nextcloud_1  | + image_version=21.0.2.1
...
```

Now we are able to open [localhost:8000](http://localhost:8000) and login as `administrator/adminpass`

Make some changes: added a user and some files. 

We are going to stop the container (CTRL + C) and update to a new version.

```
$ export NC_IMAGE_NAME=nextcloud/apache:21.0.3
docker-compose up nextcloud
```
